### PR TITLE
Fixed conversion of units for swf job import

### DIFF
--- a/lapis/job_io/swf.py
+++ b/lapis/job_io/swf.py
@@ -50,12 +50,11 @@ def swf_job_reader(iterable, resource_name_mapping={  # noqa: B006
             value = float(row[header[resource_name_mapping[key]]])
             used_value = float(row[header[used_resource_name_mapping[key]]])
             if value >= 0:
-                resources[key] = value * used_resource_name_mapping.get(
+                resources[key] = value * unit_conversion_mapping.get(
                     resource_name_mapping[key], 1)
             if used_value >= 0:
-                used_resources[key] = used_value * used_resource_name_mapping.get(
+                used_resources[key] = used_value * unit_conversion_mapping.get(
                     used_resource_name_mapping[key], 1)
-            resources[key] = float()
         # handle memory
         key = "memory"
         resources[key] = \


### PR DESCRIPTION
The job import for swf file format did not work properly due to two mistakes in the code:

1. the unit conversion metrics were not properly accessed
2. the value itself was reset after calculation