### PR TITLE
Enable logging to telegraf via UDP

### DIFF
--- a/lapis/drone.py
+++ b/lapis/drone.py
@@ -177,7 +177,7 @@ class Drone(interfaces.Pool):
                     value = usage / (job.resources.get(resource_key, None)
                                      or self.pool_resources[resource_key])
                     if value > 1:
-                        logging.info(str(round(time.now)), {
+                        logging.info("job_status", {
                             "job_exceeds_%s" % resource_key: {
                                 repr(job): value
                             }

--- a/lapis/job.py
+++ b/lapis/job.py
@@ -31,7 +31,7 @@ def job_demand(simulator):
         value = round(value)
         if value > 0:
             simulator.global_demand.put(value)
-            logging.info(str(round(simulator.env.now)), {"user_demand_new": value})
+            logging.info("user_demand", {"user_demand_new": value})
 
 
 class Job(object):
@@ -87,7 +87,7 @@ class Job(object):
 
     async def run(self):
         self.in_queue_until = time.now
-        logging.info(str(round(time.now)), {
+        logging.info("job_status", {
             "job_queue_time": {
                 repr(self): self.queue_date
             }, "job_waiting_time": {
@@ -102,7 +102,7 @@ class Job(object):
             self._success = False
             raise
         else:
-            logging.info(str(round(time.now)), {
+            logging.info("job_status", {
                 "job_wall_time": {
                     repr(self): self.walltime
                 }
@@ -133,6 +133,6 @@ async def job_to_queue_scheduler(job_generator, job_queue, **kwargs):
             job = None
         else:
             if count > 0:
-                logging.info(str(round(time.now)), {"user_demand_new": count})
+                logging.info("user_demand", {"user_demand_new": count})
                 count = 0
             await (time == current_time)

--- a/lapis/utility/monitor.py
+++ b/lapis/utility/monitor.py
@@ -2,7 +2,7 @@ from typing import Callable, TYPE_CHECKING
 
 import logging
 
-from usim import each, Flag, time
+from usim import each, Flag
 
 from lapis.cost import cobald_cost
 
@@ -22,14 +22,13 @@ class Monitoring(object):
         async for _ in each(delay=1):
             await sampling_required
             await sampling_required.set(False)
-            result = {}
-            for statistic in self._statistics:
+            for name, statistic in self._statistics:
                 # do the logging
-                result.update(statistic(self.simulator))
-            logging.info(str(round(time.now)), result)
+                logging.info(name, statistic(self.simulator))
 
-    def register_statistic(self, statistic: Callable):
-        self._statistics.append(statistic)
+    def register_statistic(self, statistic: Callable, name: str = "lapis_data"):
+        assert name is not None
+        self._statistics.append((name, statistic))
 
 
 def collect_resource_statistics(simulator: "Simulator") -> dict:


### PR DESCRIPTION
Currently the user can select logging to file or TCP via the command line interface. As we are planning to enable visualisation of data in Grafana, the user should also be able to log to telegraf. So this pull requests adds:

* parameter to enable logging to default UDP logging port in LineFormatProtocol to be consumed via Telegraf
* named context as message in logs instead of current simulation time
* setting of creation time of logs to current simulation time