### PR TITLE
Handling of StopIteration for JobGenerator

### DIFF
--- a/lapis/job.py
+++ b/lapis/job.py
@@ -96,7 +96,10 @@ async def job_to_queue_scheduler(job_generator, job_queue, **kwargs):
     count = 0
     while True:
         if not job:
-            job = next(job_generator)
+            try:
+                job = next(job_generator)
+            except StopIteration:
+                return
             current_time = job.queue_date - base_date
         if time.now >= current_time:
             count += 1


### PR DESCRIPTION
The JobGenerator did not properly handle `StopIteration` until now. This is added with this pull request.