### PR TITLE
Fixed calculation of used_ratio and requested_ratio

### DIFF
--- a/lapis/monitor/general.py
+++ b/lapis/monitor/general.py
@@ -29,11 +29,10 @@ def resource_statistics(simulator: "Simulator") -> list:
                 "pool_type": "drone",
                 "pool": repr(drone),
                 "used_ratio":
-                    used_resources.get(resource_type, 0)
-                    / drone.pool_resources.get(resource_type, 0),
+                    1 - used_resources[resource_type]
+                    / drone.pool_resources[resource_type],
                 "requested_ratio":
-                    resources.get(resource_type, 0)
-                    / drone.pool_resources.get(resource_type, 0)
+                    1 - resources[resource_type] / drone.pool_resources[resource_type]
             })
     return results
 


### PR DESCRIPTION
The calculation of `used_ratio` and `requested_ratio` was wrong after I introduced the current implementation of the borrowing concept of usim. usim gives remaining resources whereas I before handled used resources. So calculation is inversed now.