### PR TITLE
Corrected name on PyPI and RTD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "flit.buildapi"
 
 [tool.flit.metadata]
 module = "lapis"
+dist-name = "lapis-sim"
 author = "Eileen Kuehn, Max Fischer"
 author-email = "mainekuehn@gmail.com"
 home-page = "https://github.com/MatterMiners/lapis"
@@ -39,4 +40,4 @@ doc = ["sphinx", "sphinx_rtd_theme"]
 dev = ["pre-commit"]
 
 [tool.flit.metadata.urls]
-Documentation = "https://lapis.readthedocs.io/en/latest/"
+Documentation = "https://lapis-sim.readthedocs.io/en/latest/"


### PR DESCRIPTION
The name for RTD and PyPI had to be adapted as lapis was already taken. I picked *lapis-sim* now.