### PR TITLE
Usim adaptations to match most recent dev version

### DIFF
--- a/lapis/drone.py
+++ b/lapis/drone.py
@@ -1,8 +1,7 @@
 import logging
 
 from cobald import interfaces
-from usim import time, Scope, instant
-from usim.basics import Capacities, ResourcesUnavailable
+from usim import time, Scope, instant, Capacities, ResourcesUnavailable
 
 from lapis.job import Job
 

--- a/lapis/monitor/__init__.py
+++ b/lapis/monitor/__init__.py
@@ -4,7 +4,7 @@ import logging.handlers
 from typing import Callable, TYPE_CHECKING
 
 from cobald.monitor.format_json import JsonFormatter
-from usim import time, Flag, each
+from usim import time, Flag, delay
 
 if TYPE_CHECKING:
     from lapis.simulator import Simulator
@@ -38,7 +38,7 @@ class Monitoring(object):
         self._statistics = []
 
     async def run(self):
-        async for _ in each(delay=1):
+        async for _ in delay(1):
             await sampling_required
             await sampling_required.set(False)
             for statistic in self._statistics:

--- a/lapis/pool.py
+++ b/lapis/pool.py
@@ -1,6 +1,6 @@
 from typing import Generator, Callable
 from cobald import interfaces
-from usim import eternity, Scope, each
+from usim import eternity, Scope, interval
 
 from .drone import Drone
 
@@ -48,7 +48,7 @@ class Pool(interfaces.Pool):
         initialising new drones. Otherwise drones get removed.
         """
         async with Scope() as scope:
-            async for _ in each(interval=1):
+            async for _ in interval(1):
                 drones_required = min(self._demand, self._capacity) - self._level
                 while drones_required > 0:
                     drones_required -= 1

--- a/lapis/scheduler.py
+++ b/lapis/scheduler.py
@@ -1,4 +1,4 @@
-from usim import Scope, each, instant
+from usim import Scope, instant, interval
 
 from lapis.drone import Drone
 
@@ -74,7 +74,7 @@ class CondorJobScheduler(object):
     async def run(self):
         async with Scope() as scope:
             scope.do(self._collect_jobs())
-            async for _ in each(interval=self.interval):
+            async for _ in interval(self.interval):
                 for job in self.job_queue:
                     best_match = self._schedule_job(job)
                     if best_match:

--- a/lapis/simulator.py
+++ b/lapis/simulator.py
@@ -1,8 +1,7 @@
 import random
 from functools import partial
 
-from usim import run, time, until, Scope
-from usim.basics import Queue
+from usim import run, time, until, Scope, Queue
 
 from lapis.drone import Drone
 from lapis.job import job_to_queue_scheduler

--- a/lapis_tests/__init__.py
+++ b/lapis_tests/__init__.py
@@ -2,7 +2,6 @@ from typing import Callable, Coroutine
 from functools import wraps
 
 from usim import run
-from usim._core.loop import ActivityError
 
 from lapis.drone import Drone
 
@@ -26,11 +25,7 @@ def via_usim(test_case: Callable[..., Coroutine]):
         # https://github.com/pytest-dev/pytest/issues/1904
         __tracebackhide__ = True
         # >>> This is not the frame you are looking for. Do read on. <<<
-        try:
-            return run(test_case(*args, **kwargs))
-        except ActivityError as err:
-            # unwrap any exceptions
-            raise err.__cause__
+        return run(test_case(*args, **kwargs))
     return run_test
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires = [
     "cobald",
-    "usim == 0.3",
+    "usim == 0.4",
     "click",
 ]
 


### PR DESCRIPTION
To enable usage of pipe/flux of usim for caching simulation the flat namespace of usim had to be supported.
This PR handles the following issues

* [x] removal of `usim.basics` from `usim`, 
* [x] replacement of `each` by `interval` and `delay`, and
* [x] removal of `ActivityError`

Is anything important missing that I did not consider yet?