### PR TITLE
Corrected calculation and access to conversion mapping for HTCondor import

### DIFF
--- a/lapis/job_io/htcondor.py
+++ b/lapis/job_io/htcondor.py
@@ -49,11 +49,10 @@ def htcondor_job_reader(
                 pass
         used_resources = {
             "cores": (
-                float(row["RemoteSysCpu"])
-                + float(row["RemoteUserCpu"])
+                (float(row["RemoteSysCpu"]) + float(row["RemoteUserCpu"]))
                 / float(row[used_resource_name_mapping["walltime"]])
             )
-            * unit_conversion_mapping.get(used_resource_name_mapping[key], 1)
+            * unit_conversion_mapping.get(used_resource_name_mapping["cores"], 1)
         }
         for key in ["memory", "walltime", "disk"]:
             original_key = used_resource_name_mapping[key]


### PR DESCRIPTION
There were two issues with calculation of actually used cores:

1. the calculation itself was missing brackets,
2. the access to `key` was outdated and had to be replaced by `"cores"`.

Related to #48.