### PR TITLE
Skip black for pypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
     "pytest >=4.3.0",
     "flake8",
     "flake8-bugbear",
-    "black; implementation_name=='pypy'",
+    "black; implementation_name=='cpython'",
 ]
 doc = ["sphinx", "sphinx_rtd_theme"]
 dev = ["pre-commit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
     "pytest >=4.3.0",
     "flake8",
     "flake8-bugbear",
-    "black",
+    "black; implementation_name=='pypy'",
 ]
 doc = ["sphinx", "sphinx_rtd_theme"]
 dev = ["pre-commit"]


### PR DESCRIPTION
Removes ``black`` dependency entirely for ``pypy``.