### PR TITLE
Standardisation of units

### DIFF
--- a/lapis/job_io/htcondor.py
+++ b/lapis/job_io/htcondor.py
@@ -17,7 +17,6 @@ def htcondor_job_reader(
     used_resource_name_mapping={  # noqa: B006
         "queuetime": "QDate",
         "walltime": "RemoteWallClockTime",  # s
-        "cores": "Number of Allocated Processors",
         "memory": "MemoryUsage",  # MB
         "disk": "DiskUsage_RAW",  # KiB
     },
@@ -28,7 +27,6 @@ def htcondor_job_reader(
         "RequestDisk": 1.024 / 1024 / 1024,
         "queuetime": 1,
         "RemoteWallClockTime": 1,
-        "Number of Allocated Processors": 1,
         "MemoryUsage": 1 / 1024,
         "DiskUsage_RAW": 1.024 / 1024 / 1024,
     },

--- a/lapis/job_io/htcondor.py
+++ b/lapis/job_io/htcondor.py
@@ -27,7 +27,7 @@ def htcondor_job_reader(
         "RequestDisk": 1024,
         "queuetime": 1,
         "RemoteWallClockTime": 1,
-        "MemoryUsage": 1 / 1.048576 * 1024 * 1024,
+        "MemoryUsage": 1000 * 1000,
         "DiskUsage_RAW": 1024,
     },
 ):

--- a/lapis/job_io/htcondor.py
+++ b/lapis/job_io/htcondor.py
@@ -23,12 +23,12 @@ def htcondor_job_reader(
     unit_conversion_mapping={  # noqa: B006
         "RequestCpus": 1,
         "RequestWalltime": 1,
-        "RequestMemory": 1.024 / 1024,
-        "RequestDisk": 1.024 / 1024 / 1024,
+        "RequestMemory": 1024 * 1024,
+        "RequestDisk": 1024,
         "queuetime": 1,
         "RemoteWallClockTime": 1,
-        "MemoryUsage": 1 / 1024,
-        "DiskUsage_RAW": 1.024 / 1024 / 1024,
+        "MemoryUsage": 1 / 1.048576 * 1024 * 1024,
+        "DiskUsage_RAW": 1024,
     },
 ):
     input_file_type = iterable.name.split(".")[-1].lower()
@@ -49,9 +49,10 @@ def htcondor_job_reader(
         resources = {}
         for key, original_key in resource_name_mapping.items():
             try:
-                resources[key] = float(
-                    entry[original_key]
-                ) * unit_conversion_mapping.get(original_key, 1)
+                resources[key] = int(
+                    float(entry[original_key])
+                    * unit_conversion_mapping.get(original_key, 1)
+                )
             except ValueError:
                 pass
 
@@ -60,13 +61,14 @@ def htcondor_job_reader(
                 (float(entry["RemoteSysCpu"]) + float(entry["RemoteUserCpu"]))
                 / float(entry[used_resource_name_mapping["walltime"]])
             )
-            * unit_conversion_mapping.get(used_resource_name_mapping["cores"], 1)
+            * unit_conversion_mapping.get(resource_name_mapping["cores"], 1)
         }
         for key in ["memory", "walltime", "disk"]:
             original_key = used_resource_name_mapping[key]
-            used_resources[key] = float(
-                entry[original_key]
-            ) * unit_conversion_mapping.get(original_key, 1)
+            used_resources[key] = int(
+                float(entry[original_key])
+                * unit_conversion_mapping.get(original_key, 1)
+            )
 
         try:
             resources["inputfiles"] = deepcopy(entry["Inputfiles"])

--- a/lapis/job_io/swf.py
+++ b/lapis/job_io/swf.py
@@ -12,18 +12,18 @@ def swf_job_reader(
     iterable,
     resource_name_mapping={  # noqa: B006
         "cores": "Requested Number of Processors",
-        "walltime": "Requested Time",
-        "memory": "Requested Memory",
+        "walltime": "Requested Time",  # s
+        "memory": "Requested Memory",  # KiB
     },
     used_resource_name_mapping={  # noqa: B006
-        "walltime": "Run Time",
+        "walltime": "Run Time",  # s
         "cores": "Number of Allocated Processors",
-        "memory": "Used Memory",
+        "memory": "Used Memory",  # KiB
         "queuetime": "Submit Time",
     },
     unit_conversion_mapping={  # noqa: B006
-        "Used Memory": 1 / 1024 / 1024,
-        "Requested Memory": 1 / 2114 / 1024,
+        "Used Memory": 1024,
+        "Requested Memory": 1024,
     },
 ):
     header = {
@@ -71,14 +71,20 @@ def swf_job_reader(
                 )
         # handle memory
         key = "memory"
-        resources[key] = (
-            float(row[header[resource_name_mapping[key]]])
-            * float(row[header[resource_name_mapping["cores"]]])
-        ) * unit_conversion_mapping.get(resource_name_mapping[key], 1)
-        used_resources[key] = (
-            float(row[header[used_resource_name_mapping[key]]])
-            * float(row[header[used_resource_name_mapping["cores"]]])
-        ) * unit_conversion_mapping.get(used_resource_name_mapping[key], 1)
+        resources[key] = int(
+            (
+                float(row[header[resource_name_mapping[key]]])
+                * float(row[header[resource_name_mapping["cores"]]])
+            )
+            * unit_conversion_mapping.get(resource_name_mapping[key], 1)
+        )
+        used_resources[key] = int(
+            (
+                float(row[header[used_resource_name_mapping[key]]])
+                * float(row[header[used_resource_name_mapping["cores"]]])
+            )
+            * unit_conversion_mapping.get(used_resource_name_mapping[key], 1)
+        )
         yield Job(
             resources=resources,
             used_resources=used_resources,

--- a/lapis/pool_io/htcondor.py
+++ b/lapis/pool_io/htcondor.py
@@ -14,8 +14,8 @@ def htcondor_pool_reader(
     },
     unit_conversion_mapping: dict = {  # noqa: B006
         "TotalSlotCPUs": 1,
-        "TotalSlotDisk": 1.024 / 1024,
-        "TotalSlotMemory": 1.024 / 1024,
+        "TotalSlotDisk": 1024 * 1024,
+        "TotalSlotMemory": 1024 * 1024,
     },
     pool_type: Callable = Pool,
     make_drone: Callable = None,
@@ -44,7 +44,7 @@ def htcondor_pool_reader(
             make_drone=partial(
                 make_drone,
                 {
-                    key: float(row[value]) * unit_conversion_mapping.get(value, 1)
+                    key: int(float(row[value]) * unit_conversion_mapping.get(value, 1))
                     for key, value in resource_name_mapping.items()
                 },
                 ignore_resources=["disk"],

--- a/lapis/pool_io/machines.py
+++ b/lapis/pool_io/machines.py
@@ -11,6 +11,10 @@ def machines_pool_reader(
         "cores": "CPUs_per_node",
         "memory": "RAM_per_node_in_KB",
     },
+    unit_conversion_mapping={  # noqa: B006
+        "CPUs_per_node": 1,
+        "RAM_per_node_in_KB": 1000,
+    },
     pool_type: Callable = Pool,
     make_drone: Callable = None,
 ):
@@ -33,7 +37,7 @@ def machines_pool_reader(
             make_drone=partial(
                 make_drone,
                 {
-                    key: float(row[value])
+                    key: int(float(row[value]) * unit_conversion_mapping.get(value, 1))
                     for key, value in resource_name_mapping.items()
                 },
             ),


### PR DESCRIPTION
This pull requests implements the discussion in #58. We decided to convert everything to Byte and use ``int`` as the data type.
This pull requests fixes implementation for

* [x] HTCondor, assuming, that ``RequestDisk`` and ``DiskUsage_RAW`` are given in KiB, ``RequestMemory`` in MiB, and ``MemoryUsage`` in MB.
* [x] SWF, assuming, that the [standard 2.2](https://www.cse.huji.ac.il/labs/parallel/workload/swf.html) written in 2006 means KiB when talking about KB.

Closes #58.