### PR TITLE
Runnings jobs independently from scheduler

### DIFF
--- a/lapis/drone.py
+++ b/lapis/drone.py
@@ -154,6 +154,9 @@ class Drone(interfaces.Pool):
                 await instant
                 job_execution.cancel()
             self.jobs -= 1
+            if not job.successful:
+                job.drone = None
+                await self.scheduler.retry_job(job)
             self._utilisation = self._allocation = None
             self.scheduler.update_drone(self)
             await sampling_required.put(self)

--- a/lapis/drone.py
+++ b/lapis/drone.py
@@ -1,5 +1,5 @@
 from cobald import interfaces
-from usim import time, Scope, instant, Capacities, ResourcesUnavailable
+from usim import time, Scope, instant, Capacities, ResourcesUnavailable, Queue
 
 from lapis.job import Job
 
@@ -44,6 +44,7 @@ class Drone(interfaces.Pool):
         self.jobs = 0
         self._allocation = None
         self._utilisation = None
+        self._job_queue = Queue()
 
     @property
     def theoretical_available_resources(self):
@@ -60,6 +61,9 @@ class Drone(interfaces.Pool):
         self._supply = 1
         self.scheduler.register_drone(self)
         await sampling_required.put(self)
+        async with Scope() as scope:
+            async for job, kill in self._job_queue:
+                scope.do(self._run_job(job=job, kill=kill))
 
     @property
     def supply(self) -> float:
@@ -103,7 +107,10 @@ class Drone(interfaces.Pool):
         await sampling_required.put(self)  # TODO: introduce state of drone
         await (time + 1)
 
-    async def start_job(self, job: Job, kill: bool = False):
+    async def schedule_job(self, job: Job, kill: bool = False):
+        await self._job_queue.put((job, kill))
+
+    async def _run_job(self, job: Job, kill: bool):
         """
         Method manages to start a job in the context of the given drone.
         The job is started independent of available resources. If resources of

--- a/lapis/scheduler.py
+++ b/lapis/scheduler.py
@@ -111,6 +111,9 @@ class CondorJobScheduler(object):
             await sampling_required.put(self.job_queue)
         self._collecting = False
 
+    async def retry_job(self, job):
+        await self._stream_queue.put(job)
+
     def _schedule_job(self, job) -> Drone:
         priorities = {}
         for cluster in self.drone_cluster:

--- a/lapis/scheduler.py
+++ b/lapis/scheduler.py
@@ -90,7 +90,7 @@ class CondorJobScheduler(object):
                 for job in self.job_queue:
                     best_match = self._schedule_job(job)
                     if best_match:
-                        scope.do(best_match.start_job(job))
+                        await best_match.schedule_job(job)
                         self.job_queue.remove(job)
                         await sampling_required.put(self.job_queue)
                         self.unregister_drone(best_match)

--- a/lapis_tests/test_job.py
+++ b/lapis_tests/test_job.py
@@ -47,9 +47,10 @@ class TestJob(object):
             pool_resources={"cores": 1, "memory": 1},
             scheduling_duration=0,
         )
+        await drone.run()
         async with Scope() as scope:
-            scope.do(drone.start_job(job=job))
-        assert 10 == time
+            scope.do(drone.schedule_job(job=job))
+        assert 10 == time.now
         assert 0 == job.waiting_time
         assert job.successful
 
@@ -65,8 +66,9 @@ class TestJob(object):
             pool_resources={"cores": 1, "memory": 1},
             scheduling_duration=0,
         )
+        await drone.run()
         async with Scope() as scope:
-            scope.do(drone.start_job(job=job))
+            scope.do(drone.schedule_job(job=job))
         assert 0 == time
         assert not job.successful
         assert 0 == job.waiting_time
@@ -87,9 +89,10 @@ class TestJob(object):
             pool_resources={"cores": 1, "memory": 1},
             scheduling_duration=0,
         )
+        await drone.run()
         async with Scope() as scope:
-            scope.do(drone.start_job(job=job_one))
-            scope.do(drone.start_job(job=job_two))
+            scope.do(drone.schedule_job(job=job_one))
+            scope.do(drone.schedule_job(job=job_two))
         assert 10 == time
         assert job_one.successful
         assert not job_two.successful
@@ -112,9 +115,10 @@ class TestJob(object):
             pool_resources={"cores": 2, "memory": 2},
             scheduling_duration=0,
         )
+        await drone.run()
         async with Scope() as scope:
-            scope.do(drone.start_job(job=job_one))
-            scope.do(drone.start_job(job=job_two))
+            scope.do(drone.schedule_job(job=job_one))
+            scope.do(drone.schedule_job(job=job_two))
         assert 10 == time
         assert job_one.successful
         assert job_two.successful


### PR DESCRIPTION
As reported by @tfesenbecker the jobs did not run independently from the scheduling cycle (see #60). This PR fixes this issue by introducing a `Queue` into the drone for starting jobs. The drone itself tries to start jobs that are sent to this queue. If it is not possible, jobs get canceled. If a job is cancelled it is now send for further scheduling to the job queue within the scheduler. 

This PR includes:

* [x] introduction of queue in drones
* [x] possibility to resend unsuccessful jobs to scheduler
* [x] initialising and running drones within dynamic and static pools

Closes #60.