### PR TITLE
Drone as a requirement to run a job

### DIFF
--- a/lapis/drone.py
+++ b/lapis/drone.py
@@ -127,7 +127,7 @@ class Drone(interfaces.Pool):
 
             self._utilisation = self._allocation = None
 
-            job_execution = scope.do(job.run())
+            job_execution = scope.do(job.run(self))
             self.jobs += 1
             try:
                 async with self.resources.claim(
@@ -154,7 +154,6 @@ class Drone(interfaces.Pool):
                 await instant
                 job_execution.cancel()
             self.jobs -= 1
-            job.drone = None
             await self.scheduler.job_finished(job)
             self._utilisation = self._allocation = None
             self.scheduler.update_drone(self)

--- a/lapis/job.py
+++ b/lapis/job.py
@@ -92,6 +92,7 @@ class Job(object):
         return float("Inf")
 
     async def run(self, drone: "Drone"):
+        assert drone, "Jobs cannot run without a drone being assigned"
         self.drone = drone
         self.in_queue_until = time.now
         self._success = None

--- a/lapis/job.py
+++ b/lapis/job.py
@@ -91,18 +91,22 @@ class Job(object):
             return self.in_queue_until - self.in_queue_since
         return float("Inf")
 
-    async def run(self):
+    async def run(self, drone: "Drone"):
+        self.drone = drone
         self.in_queue_until = time.now
         self._success = None
         await sampling_required.put(self)
         try:
             await (time + self.walltime)
         except CancelTask:
+            self.drone = None
             self._success = False
         except BaseException:
+            self.drone = None
             self._success = False
             raise
         else:
+            self.drone = None
             self._success = True
         await sampling_required.put(self)
 

--- a/lapis_tests/__init__.py
+++ b/lapis_tests/__init__.py
@@ -43,3 +43,7 @@ class DummyScheduler:
     @staticmethod
     def update_drone(drone: Drone):
         pass
+
+
+class DummyDrone:
+    pass

--- a/lapis_tests/test_job.py
+++ b/lapis_tests/test_job.py
@@ -3,7 +3,7 @@ from usim import Scope, time
 
 from lapis.drone import Drone
 from lapis.job import Job
-from lapis_tests import via_usim, DummyScheduler
+from lapis_tests import via_usim, DummyScheduler, DummyDrone
 
 
 class TestJob(object):
@@ -27,10 +27,11 @@ class TestJob(object):
 
     @via_usim
     async def test_run_job(self):
+        drone = DummyDrone()
         job = Job(resources={"walltime": 50}, used_resources={"walltime": 10})
         assert float("inf") == job.waiting_time
         async with Scope() as scope:
-            scope.do(job.run())
+            scope.do(job.run(drone))
         assert 10 == time
         assert 0 == job.waiting_time
         assert job.successful


### PR DESCRIPTION
Before it was possible to actually run a job without the actual resources that are required. We now use a parameter for the drone to start running the job.

Closes #55.