### PR TITLE
Renamed change fragment

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,8 +11,8 @@ Upcoming
 Version [Unreleased] - 2019-11-27
 +++++++++++++++++++++++++++++++++
 
-* **[Added]** Changelog
 * **[Added]** Basic documentation
+* **[Added]** Changelog
 * **[Added]** Information about input files for jobs
 * **[Added]** Drone as a requirement to run a job
 

--- a/docs/source/changes/74.changelog.yaml
+++ b/docs/source/changes/74.changelog.yaml
@@ -3,4 +3,4 @@ summary: "Changelog"
 description: |
   The documentation now includes a changelog up to the current version.
 pull requests:
-  - 68
+  - 74


### PR DESCRIPTION
The change fragment for setting up changelogs referenced the wrong PR number. This is corrected in this PR.