### PR TITLE
Fixed that drones could be registered twice

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,7 @@ Version [Unreleased] - 2019-11-29
 
 * **[Changed]** Standardisation of units
 
-* **[Fixed]** Registering of drones
+* **[Fixed]** Duplicate registration of drones
 * **[Fixed]** Handling of black for pypy
 * **[Fixed]** Proper termination of simulation
 * **[Fixed]** Jobs execution within drones

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by log.py at 2019-11-27, command
+.. Created by log.py at 2019-11-29, command
    '/Users/eileenwork/development/work/lapis/venv/lib/python3.7/site-packages/change/__main__.py log docs/source/changes compile --output docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 #########
@@ -8,7 +8,7 @@ ChangeLog
 Upcoming
 ========
 
-Version [Unreleased] - 2019-11-27
+Version [Unreleased] - 2019-11-29
 +++++++++++++++++++++++++++++++++
 
 * **[Added]** Basic documentation
@@ -18,6 +18,7 @@ Version [Unreleased] - 2019-11-27
 
 * **[Changed]** Standardisation of units
 
+* **[Fixed]** Registering of drones
 * **[Fixed]** Handling of black for pypy
 * **[Fixed]** Proper termination of simulation
 * **[Fixed]** Jobs execution within drones

--- a/docs/source/changes/76.register_drones.yaml
+++ b/docs/source/changes/76.register_drones.yaml
@@ -1,5 +1,5 @@
 category: fixed
-summary: "Registering of drones"
+summary: "Duplicate registration of drones"
 description: |
   At startup drones were registered twice at the scheduler as the method
   ``register_drone`` was called during initialisation and in ``run``.

--- a/docs/source/changes/76.register_drones.yaml
+++ b/docs/source/changes/76.register_drones.yaml
@@ -1,0 +1,7 @@
+category: fixed
+summary: "Registering of drones"
+description: |
+  At startup drones were registered twice at the scheduler as the method
+  ``register_drone`` was called during initialisation and in ``run``.
+pull requests:
+  - 76

--- a/lapis/drone.py
+++ b/lapis/drone.py
@@ -36,11 +36,7 @@ class Drone(interfaces.Pool):
         else:
             self._valid_resource_keys = self.pool_resources.keys()
         self.scheduling_duration = scheduling_duration
-        if scheduling_duration == 0:
-            self._supply = 1
-            self.scheduler.register_drone(self)
-        else:
-            self._supply = 0
+        self._supply = 0
         self.jobs = 0
         self._allocation = None
         self._utilisation = None


### PR DESCRIPTION
For each drone during initialisation and after startup the `register_drone` method at the scheduler was called resulting in each drone being registered twice. This is fixed now.