### PR TITLE
Scheduler now considers all jobs in a scheduling cycle

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by log.py at 2019-11-29, command
+.. Created by log.py at 2019-11-30, command
    '/Users/eileenwork/development/work/lapis/venv/lib/python3.7/site-packages/change/__main__.py log docs/source/changes compile --output docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 #########
@@ -8,7 +8,7 @@ ChangeLog
 Upcoming
 ========
 
-Version [Unreleased] - 2019-11-29
+Version [Unreleased] - 2019-11-30
 +++++++++++++++++++++++++++++++++
 
 * **[Added]** Basic documentation
@@ -22,6 +22,7 @@ Version [Unreleased] - 2019-11-29
 * **[Fixed]** Handling of black for pypy
 * **[Fixed]** Proper termination of simulation
 * **[Fixed]** Jobs execution within drones
+* **[Fixed]** Scheduling of jobs
 * **[Fixed]** Importing of HTCondor jobs
 
 0.3 Series

--- a/docs/source/changes/79.jobqueue_removal.yaml
+++ b/docs/source/changes/79.jobqueue_removal.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: "Scheduling of jobs"
+description: |
+  During the scheduling cycle the original job queue was used although jobs
+  could be removed during scheduling. Now scheduling is performed on a copy
+  of the job queue.
+pull requests:
+  - 79

--- a/lapis/scheduler.py
+++ b/lapis/scheduler.py
@@ -88,7 +88,7 @@ class CondorJobScheduler(object):
         async with Scope() as scope:
             scope.do(self._collect_jobs())
             async for _ in interval(self.interval):
-                for job in self.job_queue:
+                for job in self.job_queue.copy():
                     best_match = self._schedule_job(job)
                     if best_match:
                         await best_match.schedule_job(job)


### PR DESCRIPTION
When a job was successfully scheduled during scheduling the removal of the job caused the next job to be ignored as the list has not been copied properly. This PR fixes this behaviour.