### PR TITLE
Job cancellation

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by log.py at 2019-11-30, command
+.. Created by log.py at 2019-12-12, command
    '/Users/eileenwork/development/work/lapis/venv/lib/python3.7/site-packages/change/__main__.py log docs/source/changes compile --output docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 #########
@@ -8,7 +8,7 @@ ChangeLog
 Upcoming
 ========
 
-Version [Unreleased] - 2019-11-30
+Version [Unreleased] - 2019-12-12
 +++++++++++++++++++++++++++++++++
 
 * **[Added]** Basic documentation
@@ -23,6 +23,7 @@ Version [Unreleased] - 2019-11-30
 * **[Fixed]** Proper termination of simulation
 * **[Fixed]** Jobs execution within drones
 * **[Fixed]** Scheduling of jobs
+* **[Fixed]** Cancelation of jobs
 * **[Fixed]** Importing of HTCondor jobs
 
 0.3 Series
@@ -64,3 +65,4 @@ Version [0.1.1] - 2019-10-24
 * **[Fixed]** Calculation of used and requested resource ratio
 * **[Fixed]** StopIteration handling by Job Generator
 * **[Fixed]** Importing of SWF files
+

--- a/docs/source/changes/80.job_cancelation.yaml
+++ b/docs/source/changes/80.job_cancelation.yaml
@@ -1,0 +1,8 @@
+category: fixed
+summary: "Cancelation of jobs"
+description: |
+  When a drone tried to cancel a job it could happen that the success state
+  of that job was not properly set as the job was not yet in running state.
+  This is fixed now by additionally waiting for an `instant`.
+pull requests:
+  - 80

--- a/lapis/drone.py
+++ b/lapis/drone.py
@@ -137,7 +137,9 @@ class Drone(interfaces.Pool):
                                     job.resources[resource_key]
                                     < job.used_resources[resource_key]
                                 ):
+                                    await instant
                                     job_execution.cancel()
+                                    await instant
                             except KeyError:
                                 # check is not relevant if the data is not stored
                                 pass
@@ -146,9 +148,11 @@ class Drone(interfaces.Pool):
             except ResourcesUnavailable:
                 await instant
                 job_execution.cancel()
+                await instant
             except AssertionError:
                 await instant
                 job_execution.cancel()
+                await instant
             self.jobs -= 1
             await self.scheduler.job_finished(job)
             self._utilisation = self._allocation = None


### PR DESCRIPTION
Job cancellation from drones sometimes did not properly result in the expected state. When the drone tried to `cancel` a job it could happen that the success state of a drone was not properly set to `False` as the job had not been properly started before. This PR includes a fix for this issue.